### PR TITLE
Fix SQLite threading error

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,8 @@ import gradio as gr
 # Modelo
 class NotasDB:
     def __init__(self, db_name="notas.db"):
-        self.conn = sqlite3.connect(db_name)
+        # Allow connection to be used from Gradio's worker threads
+        self.conn = sqlite3.connect(db_name, check_same_thread=False)
         self.crear_tabla()
 
     def crear_tabla(self):


### PR DESCRIPTION
## Summary
- allow SQLite connection across threads for Gradio

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686ee6830c38832680d943663ff9a65c